### PR TITLE
use `puts` instead `printf`

### DIFF
--- a/packs/baran/data/usr/share/templates/untitled.c
+++ b/packs/baran/data/usr/share/templates/untitled.c
@@ -2,6 +2,6 @@
 
 int main ()
 {
-    printf ("Welcome to Pyabr with C programing language.");
+    puts ("Welcome to Pyabr with C programing language.");
     return 0;
 }


### PR DESCRIPTION
`puts(char*)` receives a string and print newline (`'\n'`) automatically.
`printf(char*,...)` is used when you want print some values stored in some variables